### PR TITLE
New 'finalNameUsedForVersion' parameter in CreateNewVersionMojo

### DIFF
--- a/src/main/java/com/george/plugins/jira/CreateNewVersionMojo.java
+++ b/src/main/java/com/george/plugins/jira/CreateNewVersionMojo.java
@@ -3,6 +3,7 @@ package com.george.plugins.jira;
 import java.util.Comparator;
 
 import org.apache.maven.plugin.logging.Log;
+import org.codehaus.plexus.util.StringUtils;
 
 import com.atlassian.jira.rpc.soap.client.JiraSoapService;
 import com.atlassian.jira.rpc.soap.client.RemoteVersion;
@@ -28,6 +29,18 @@ public class CreateNewVersionMojo extends AbstractJiraMojo {
 	String developmentVersion;
 
 	/**
+	 * @parameter default-value="${project.build.finalName}"
+	 */
+	String finalName;
+	
+	/**
+	 * Whether the final name is to be used for the version; defaults to false.
+	 * 
+	 * @parameter expression="${finalNameUsedForVersion}"
+	 */
+	boolean finalNameUsedForVersion;
+	
+	/**
 	 * Comparator for discovering the latest release
 	 * 
 	 * @parameter 
@@ -42,9 +55,15 @@ public class CreateNewVersionMojo extends AbstractJiraMojo {
 		log.debug("Login Token returned: " + loginToken);
 		RemoteVersion[] versions = jiraService.getVersions(loginToken,
 				jiraProjectKey);
-		// Removing -SNAPSHOT suffix for safety
-		String newDevVersion = developmentVersion.replace("-SNAPSHOT",
-				"");
+		String newDevVersion;
+		if (finalNameUsedForVersion) {
+			newDevVersion = finalName;
+		} else {
+			newDevVersion = developmentVersion;
+		}
+		// Removing -SNAPSHOT suffix for safety and sensible formatting
+		newDevVersion = StringUtils.capitaliseAllWords(
+				newDevVersion.replace("-SNAPSHOT", "").replace("-", " "));
 		boolean versionExists = isVersionAlreadyPresent(versions,
 				newDevVersion);
 		if (!versionExists) {

--- a/src/test/java/com/george/plugins/jira/CreateNewVersionMojoTest.java
+++ b/src/test/java/com/george/plugins/jira/CreateNewVersionMojoTest.java
@@ -77,6 +77,54 @@ public class CreateNewVersionMojoTest {
 		jiraVersionMojo.execute();
 	}
 	
+	@Test
+	public void testExecuteWithNewDevVersionIncludingQualifierAndSnapshot() throws Exception {
+		jiraVersionMojo.developmentVersion = "5.0-beta-2-SNAPSHOT";
+		doLoginBehavior();
+		// Chama o getVersions
+		expect(
+				jiraStub.getVersions(LOGIN_TOKEN,
+						jiraVersionMojo.jiraProjectKey)).andReturn(VERSIONS)
+				.once();
+
+		// Adiciona a nova versao
+		expect(
+				jiraStub.addVersion(LOGIN_TOKEN,
+						jiraVersionMojo.jiraProjectKey, new RemoteVersion(null,
+								"5.0 Beta 2", false,
+								null, false, null))).andReturn(VERSIONS[0]);
+		doLogoutBehavior();
+		// Habilita o controle para inicio dos testes
+		EasyMock.replay(jiraStub);
+
+		jiraVersionMojo.execute();
+	}
+	
+	@Test
+	public void testExecuteWithNewDevVersionAndUseFinalNameForVersionSetToTrue() throws Exception {
+		jiraVersionMojo.developmentVersion = "5.0-beta-2-SNAPSHOT";
+		jiraVersionMojo.finalNameUsedForVersion = true;
+		jiraVersionMojo.finalName = "my-component-5.0-beta-2-SNAPSHOT";
+		doLoginBehavior();
+		// Chama o getVersions
+		expect(
+				jiraStub.getVersions(LOGIN_TOKEN,
+						jiraVersionMojo.jiraProjectKey)).andReturn(VERSIONS)
+				.once();
+
+		// Adiciona a nova versao
+		expect(
+				jiraStub.addVersion(LOGIN_TOKEN,
+						jiraVersionMojo.jiraProjectKey, new RemoteVersion(null,
+								"My Component 5.0 Beta 2", false,
+								null, false, null))).andReturn(VERSIONS[0]);
+		doLogoutBehavior();
+		// Habilita o controle para inicio dos testes
+		EasyMock.replay(jiraStub);
+
+		jiraVersionMojo.execute();
+	}
+	
 	/**
 	 * Test method for {@link ReleaseVersionMojo#execute()}
 	 * 


### PR DESCRIPTION
Added a new boolean mojo parameter 'finalNameUsedForVersion'; if true, the
project final name is used for the version instead of the
'developmentVersion' parameter.

Also, some additional formatting is done on the Jira version before being created.
